### PR TITLE
Forcing pid and tid in class_mist.convert_thread() to be converted in…

### DIFF
--- a/cuckoo2mist/class_mist.py
+++ b/cuckoo2mist/class_mist.py
@@ -164,7 +164,7 @@ class mistit(object):
 	
 		
 	def convert_thread(self, pid, tid, api_calls):
-		self.mist.write( '# process ' + pid + ' thread ' + tid + ' #\n' )
+		self.mist.write( '# process ' + str(pid) + ' thread ' + str(tid) + ' #\n' )
 		for api_call in api_calls:
 			arguments 	= api_call['arguments']
 			category 	= api_call['category']


### PR DESCRIPTION
…to string before "mist.writing" them

pid and tid are converted into Numeric value by the json module and can't be concatenated with a string.
This lead to an error while processing the cuckoo report.
